### PR TITLE
fix: Remove embeded `become' to let the user decide at import time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Then just call the role.
   vars:
     pkginstall_packages: "{{ first_role_packages + second_role_packages }}"
   roles:
-    - { role: cans.package-install }
-    - { role: first_role }
-    - { role: second_role }
+    - role: cans.package-install
+    - role: first_role
+    - role: second_role
 ```
 
 If for some reason you _cannot_ install all the packages at once (_e.g._
@@ -78,10 +78,26 @@ able to install the packages required by `second_role`:
   roles:
     - role: cans.package-install
       pkginstall_packages: "{{ first_role_packages }}"
-    - { role: first_role }
+    - role: first_role
     - role: cans.package-install
       pkginstall_packages: "{{ second_role_packages }}"
-    - { role: second_role }
+    - role: second_role
+```
+
+The above examples assume Ansible connects to the target servers with an identity
+that as sufficient privileges to install packages. If not you may need to use the
+either or both of the `remote_user` and `become` keywords:
+
+```yaml
+- hosts: servers
+  remote_user: "privileged_user"
+  vars:
+    pkginstall_packages: "{{ first_role_packages + second_role_packages }}"
+  roles:
+    - role: cans.package-install
+      become: yes
+    - role: first_role
+    - role: second_role
 ```
 
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   license: GPLv2
 
   min_ansible_version: 2.2  # Not tested with other versions
-  github_branch: master
+  # github_branch: master
 
   platforms:
   - name: Ubuntu

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,6 @@
     name: "{{item}}"
     state: "present"
     update_cache: "{{pkginstall_update_cache}}"
-  become: yes
   when: "ansible_distribution in ['Debian', 'Ubuntu', ]"
   with_items: "{{pkginstall_packages}}"
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: servers
+- name: "cans.package-install Role Test Suite"
+  hosts: servers
   remote_user: root
   pre_tasks:
     - name: "Ensure vim's not already installed"
@@ -12,6 +13,7 @@
     - role: "package-install"
       pkginstall_packages:
         - vim
+      become: yes
 
   tasks:
     - name: "Ensure vim was installed"


### PR DESCRIPTION
Role task was embeding a `become' instruction, which may not be desirable in all
circumstances. This version removes it, which changes the way this role can be
used. Examples in the README file have been updated accordingly.

THIS IS A BREAKING CHANGE INCOMPATIBLE WITH PREVIOUS VERSION OF THE ROLE.